### PR TITLE
Configure Next.js Image component for DALL-E image URLs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'oaidalleapiprodscus.blob.core.windows.net',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
Added remotePatterns configuration to allow Next.js Image component to load images from OpenAI's DALL-E blob storage domain:
- oaidalleapiprodscus.blob.core.windows.net

This fixes the "hostname is not configured under images" error that occurs when displaying generated coloring pages.